### PR TITLE
fix: configure vitest to pass when no tests found in workflow-registry

### DIFF
--- a/packages/workflow-registry/vitest.config.ts
+++ b/packages/workflow-registry/vitest.config.ts
@@ -4,5 +4,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
+    passWithNoTests: true,
   },
 });


### PR DESCRIPTION
The workflow-registry package currently has no test files, which caused vitest to exit with code 1 during CI checks. Added passWithNoTests: true to the vitest configuration to allow CI to pass until tests are implemented.

This resolves the test failure: "No test files found, exiting with code 1"